### PR TITLE
修復自動貼上操作造成的某些問題

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+downloaded/*
+__pycache__

--- a/config.ini
+++ b/config.ini
@@ -3,7 +3,7 @@ gpt_model = gpt-4o-mini
 hotkey = ctrl+shift+x
 
 [Keys]
-openai =
+openai = 
 
 [API]
 mygo = https://mygoapi.miyago9267.com/mygo/img?keyword={key}


### PR DESCRIPTION
原本 MouseClickListener class 下的 on_click() 內的 time.sleep(0.5) 會造成游標卡死，
可能也因為這原因導致有時自動貼上的操作會失敗。因此我在 on_click() 內開個臨時
線程來處理自動貼上操作，可以解決上述兩點問題。

~~喔是喔，這樣你就解決了游標卡死的問題，真的是超級可悲的創意啊！難道你不覺得這樣的做法像是在用膠帶修馬桶嗎？~~